### PR TITLE
:bug: 修复因`enka`的`nameTextMapHash`转变为int类型带来的错误

### DIFF
--- a/nonebot_plugin_gspanel/data_convert.py
+++ b/nonebot_plugin_gspanel/data_convert.py
@@ -31,7 +31,9 @@ async def getRelicConfig(char: str, base: Dict = {}) -> Tuple[Dict, Dict, Dict]:
     * ``param base: Dict = {}`` 角色的基础数值，可由 Enka 返回获得，格式为 ``{"生命值": 1, "攻击力": 1, "防御力": 1}``
     - ``return: Tuple[Dict, Dict, Dict]`` 词条评分权重、词条数值原始权重、各位置圣遗物最高得分
     """  # noqa: E501
-    affixWeight = CALC_RULES.get(char, {"攻击力百分比": 75, "暴击率": 100, "暴击伤害": 100})
+    affixWeight = CALC_RULES.get(
+        char, {"攻击力百分比": 75, "暴击率": 100, "暴击伤害": 100}
+    )
     # 词条评分权重的 key 排序影响最优主词条选择
     # 通过特定排序使同等权重时生命攻击防御固定值词条优先级最低
     # key 的原始排序为 生命值攻击力防御力百分比、暴击率、暴击伤害、元素精通、元素伤害加成、物理伤害加成、元素充能效率
@@ -159,7 +161,11 @@ async def calcRelicMark(
         _subPointMark: float = pointMark.get(s["prop"], 0)
         calcSub: float = _subPointMark * s["value"] * 46.6 / 6 / 100
         # 副词条 CSS 样式
-        _awKey = f"{s['prop']}百分比" if s["prop"] in ["生命值", "攻击力", "防御力"] else s["prop"]
+        _awKey = (
+            f"{s['prop']}百分比"
+            if s["prop"] in ["生命值", "攻击力", "防御力"]
+            else s["prop"]
+        )
         _subAffixWeight: int = affixWeight.get(_awKey, 0)
         subStyleClass = (
             ("great" if _subAffixWeight > 79 else "use") if calcSub else "unuse"
@@ -303,7 +309,9 @@ async def transFromEnka(avatarInfo: Dict, ts: int = 0) -> Dict:
             res["weapon"] = {
                 "id": equip["itemId"],
                 "rarity": equip["flat"]["rankLevel"],  # int
-                "name": HASH_TRANS.get(equip["flat"]["nameTextMapHash"], "缺少翻译"),
+                "name": HASH_TRANS.get(
+                    str(equip["flat"]["nameTextMapHash"]), "缺少翻译"
+                ),
                 "affix": list(equip["weapon"].get("affixMap", {"_": 0}).values())[0]
                 + 1,
                 "level": equip["weapon"]["level"],  # int
@@ -326,8 +334,12 @@ async def transFromEnka(avatarInfo: Dict, ts: int = 0) -> Dict:
             relicData = {
                 "pos": posIdx,
                 "rarity": equip["flat"]["rankLevel"],
-                "name": HASH_TRANS.get(equip["flat"]["nameTextMapHash"], "缺少翻译"),
-                "setName": HASH_TRANS.get(equip["flat"]["setNameTextMapHash"], "缺少翻译"),
+                "name": HASH_TRANS.get(
+                    str(equip["flat"]["nameTextMapHash"]), "缺少翻译"
+                ),
+                "setName": HASH_TRANS.get(
+                    str(equip["flat"]["setNameTextMapHash"]), "缺少翻译"
+                ),
                 "level": equip["reliquary"]["level"] - 1,
                 "main": {
                     "prop": PROP[mainProp["mainPropId"]],
@@ -526,11 +538,15 @@ async def simplFightProp(
     * ``param element: str`` 角色元素属性
     - ``return: Dict[str, Dict]`` HTML 模板需求格式面板数据
     """
-    affixWeight = CALC_RULES.get(char, {"攻击力百分比": 75, "暴击率": 100, "暴击伤害": 100})
+    affixWeight = CALC_RULES.get(
+        char, {"攻击力百分比": 75, "暴击率": 100, "暴击伤害": 100}
+    )
 
     # 排列伤害加成
     prefer = (
-        element if affixWeight.get("元素伤害加成", 0) > affixWeight.get("物理伤害加成", 0) else "物"
+        element
+        if affixWeight.get("元素伤害加成", 0) > affixWeight.get("物理伤害加成", 0)
+        else "物"
     )
     damages = sorted(
         [{"k": k, "v": v} for k, v in fightProp.items() if str(k).endswith("伤害加成")],
@@ -551,7 +567,9 @@ async def simplFightProp(
             "value": f"{round(propValue, 1)}%"
             if propTitle not in ["生命值", "攻击力", "防御力", "元素精通"]
             else round(propValue),
-            "weight": max(affixWeight.get("元素伤害加成", 0), affixWeight.get("物理伤害加成", 0))
+            "weight": max(
+                affixWeight.get("元素伤害加成", 0), affixWeight.get("物理伤害加成", 0)
+            )
             if propTitle.endswith("伤害加成")
             else affixWeight.get(propTitle) or affixWeight.get(f"{propTitle}百分比", 0),
         }


### PR DESCRIPTION
`enka`于今天的更新将`nameTextMapHash`字段类型改为int，导致获取到的名字异常，故强转下类型，实际上就改了三个`str(equip["flat"]["nameTextMapHash"])`，其他修改是由于格式化程序导致的